### PR TITLE
Cleanup after release 1.1.0

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: alibaba
 name: alicloud
-version: 1.0.0
+version: 1.1.0
 readme: README.md
 authors:
 - He Guimin (@xiaozhu36)

--- a/plugins/modules/ali_ecs_tag.py
+++ b/plugins/modules/ali_ecs_tag.py
@@ -36,7 +36,7 @@ options:
       - A hash/dictionaries of resource tags. C({"key":"value"})
 requirements:
     - "python >= 3.6"
-    - "footmark >= 1.17.0"
+    - "footmark >= 1.26.0"
 extends_documentation_fragment:
     - alibaba.alicloud.alicloud
 author:

--- a/plugins/modules/ali_image.py
+++ b/plugins/modules/ali_image.py
@@ -96,7 +96,7 @@ options:
     type: str
 requirements:
     - "python >= 3.6"
-    - "footmark >= 1.15.0"
+    - "footmark >= 1.26.0"
 extends_documentation_fragment:
     - alibaba.alicloud.alicloud
 author:

--- a/plugins/modules/ali_image_info.py
+++ b/plugins/modules/ali_image_info.py
@@ -62,7 +62,7 @@ author:
     - "He Guimin (@xiaozhu36)"
 requirements:
     - "python >= 3.6"
-    - "footmark >= 1.15.0"
+    - "footmark >= 1.26.0"
 extends_documentation_fragment:
     - alibaba.alicloud.alicloud
 '''

--- a/plugins/modules/ali_key_pair.py
+++ b/plugins/modules/ali_key_pair.py
@@ -53,7 +53,7 @@ options:
     type: bool
 requirements:
     - "python >= 3.6"
-    - "footmark >= 1.21.0"
+    - "footmark >= 1.26.0"
 extends_documentation_fragment:
     - alicloud
 author:

--- a/plugins/modules/ali_market_product_info.py
+++ b/plugins/modules/ali_market_product_info.py
@@ -62,7 +62,7 @@ author:
     - "He Guimin (@xiaozhu36)"
 requirements:
     - "python >= 3.6"
-    - "footmark >= 1.18.0"
+    - "footmark >= 1.26.0"
 extends_documentation_fragment:
     - alibaba.alicloud.alicloud
 '''


### PR DESCRIPTION
Bumps the Collection release version to 1.1.0 and requires Footmark 1.26.0 for modules that use the newly released image, tag, key-pair, and Marketplace query behavior.