### PR TITLE
fix: use FQCN for doc_fragment references to restore Galaxy docs

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: alibaba
 name: alicloud
-version: 1.1.0
+version: 1.1.1
 readme: README.md
 authors:
 - He Guimin (@xiaozhu36)

--- a/plugins/inventory/alicloud_ecs.py
+++ b/plugins/inventory/alicloud_ecs.py
@@ -15,7 +15,7 @@ requirements:
 extends_documentation_fragment:
     - inventory_cache
     - constructed
-    - alicloud
+    - alibaba.alicloud.alicloud
 description:
     - Get inventory hosts from Alicloud ECS.
     - Uses a yaml configuration file that ends with C(alicloud.(yml|yaml)).

--- a/plugins/modules/ali_ess_group.py
+++ b/plugins/modules/ali_ess_group.py
@@ -137,7 +137,7 @@ group:
     returned: expect absent
     type: dict
     sample: {
-        "configuration_id": asc-2ze4zleeettwd4sfnrkk,
+        "configuration_id": "asc-2ze4zleeettwd4sfnrkk",
         "cooldown": 300,
         "creation_time": "2018-01-08T05:42Z",
         "db_ids": null,
@@ -149,9 +149,7 @@ group:
         "status": "active",
         "vswitch_ids": [
             "vsw-2zevfsoh2v7en50w9up6u"
-        ],
-        "id": "asg-2zefe4bi0jpc3tqi8mn8",
-        "name": "foo"
+        ]
     }
 '''
 

--- a/plugins/modules/ali_key_pair.py
+++ b/plugins/modules/ali_key_pair.py
@@ -55,7 +55,7 @@ requirements:
     - "python >= 3.6"
     - "footmark >= 1.26.0"
 extends_documentation_fragment:
-    - alicloud
+    - alibaba.alicloud.alicloud
 author:
   - "Yang Liu (@liuyangc3)"
 """

--- a/plugins/modules/ali_key_pair_info.py
+++ b/plugins/modules/ali_key_pair_info.py
@@ -30,7 +30,7 @@ requirements:
     - "python >= 2.6"
     - "footmark"
 extends_documentation_fragment:
-    - alicloud
+    - alibaba.alicloud.alicloud
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
## Summary

- Fix all 72 module docs not rendering on Ansible Galaxy by changing short `alicloud` to fully-qualified `alibaba.alicloud.alicloud` in `extends_documentation_fragment` for 3 files: `ali_key_pair.py`, `ali_key_pair_info.py`, and `alicloud_ecs.py` inventory plugin
- Remove duplicate keys in `ali_ess_group.py` RETURN sample dict
- Bump version to 1.1.1

## Root cause

Three files used the unqualified short name `alicloud` instead of `alibaba.alicloud.alicloud` in `extends_documentation_fragment`. This caused `ansible-doc` to report `unknown doc_fragment(s)` during Galaxy import, which cascaded to marking all modules as having no DOCUMENTATION attribute — resulting in the entire docs page rendering empty.

## Test plan

- [x] Verified `ansible-doc -l --type module alibaba.alicloud` lists all 72 modules with zero errors
- [x] Verified `ansible-doc alibaba.alicloud.ali_key_pair` renders full documentation
- [x] Verified `ansible-doc alibaba.alicloud.ali_key_pair_info` renders full documentation
- [x] Verified `ansible-doc -t inventory alibaba.alicloud.alicloud_ecs` renders full documentation
- [ ] Build collection tarball and verify Galaxy import log has no doc_fragment errors
- [ ] Publish v1.1.1 to Galaxy and confirm all module docs render on the docs page